### PR TITLE
Switch :else literal to keyword? check

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -323,7 +323,7 @@
 
 (defmethod do-wrap :cond [f line [cond-symbol & body :as form] _]
   (if (and (= 2 (count body))
-           (= :else (first body)))
+           (keyword? (first body)))
     (f line (macroexpand `(~cond-symbol :else ~(wrap f line (second body)))))
     (wrap f line (macroexpand form))))
 


### PR DESCRIPTION
Fix a bug where conditional blocks would not count coverage for keywords that are not :else